### PR TITLE
correct pom to install library in correct mvn repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
                 </exec>
                 <exec
                     command="mvn install:install-file -Dfile=target/classes/libhopsnvml.so -DgroupId=io.hops.gpu
-                            -DartifactId=libhopsnvml -Dversion=1.0 -Dpackaging=so -DlocalRepositoryPath=${maven.repo.local}"
+                            -DartifactId=libhopsnvml -Dversion=1.0 -Dpackaging=so -DlocalRepositoryPath=${settings.localRepository}"
                               dir="${project.build.directory}/.." failonerror="true">
                 </exec>
               </target>


### PR DESCRIPTION
when running whit jenkins maven.repo.local is not returning the path of the custom local repository, this result in the library being installed in the wrong repository, it need to be replaced by settings.localRepository